### PR TITLE
Random shibboleth error message fix

### DIFF
--- a/app/routes/login-shibboleth.js
+++ b/app/routes/login-shibboleth.js
@@ -10,7 +10,7 @@ export default Ember.Route.extend(ErrorRouteMixin,  {
     var redirect = this.paramsFor('login-shibboleth')['redirect'];
     var session = this.get('session').authenticate('authenticator:shibboleth').then(()=>{
       if (redirect === null) {
-        this.sendAction('goToSettings');
+        this.transitionTo('settings');
       }
       else {
         var url = `${redirect}?token=${this.get('session.data.authenticated.token')}`;


### PR DESCRIPTION
After login with shibboleth and logout there is a random shibboleth error message in the login box. It's there because the sendAction doesn't exist in the `app/routes/login-shibboleth.js` and the login through shibboleth process redirects us to the main login page. As we get redirected from the `/login-shibboleth` to the `/login` route, the restore function of the shibboleth authenticator "logs us into" the system.

This was caused by a wrong copy-paste in this commit: https://github.com/bme-db-lab/szglab5-frontend/commit/b0fc92009a00ecce5acef3e6c1d3c6b40c27bc2a#diff-01d646b21ffc9f8bff0a4ba003d9c388R13